### PR TITLE
Added timestamps

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -2,6 +2,6 @@
 
 angular.module('totemDashboard', ['ngAnimate', 'ngSanitize', 'ngMessages', 'ngMaterial', 'ngWebSocket', 'ui.router', 'elasticsearch', 'jsonFormatter', 'gantt', 'gantt.tree'])
   .config(function ($urlRouterProvider) {
-    $urlRouterProvider.otherwise('/apps');
+    // $urlRouterProvider.otherwise('/apps');
   })
 ;

--- a/app/app.js
+++ b/app/app.js
@@ -2,6 +2,6 @@
 
 angular.module('totemDashboard', ['ngAnimate', 'ngSanitize', 'ngMessages', 'ngMaterial', 'ngWebSocket', 'ui.router', 'elasticsearch', 'jsonFormatter', 'gantt', 'gantt.tree'])
   .config(function ($urlRouterProvider) {
-    // $urlRouterProvider.otherwise('/apps');
+    $urlRouterProvider.when('', '/apps');
   })
 ;

--- a/app/components/api/api.service.js
+++ b/app/components/api/api.service.js
@@ -37,6 +37,10 @@ angular.module('totemDashboard')
         source.startedAt = moment(source['started-at'], format);
       }
 
+      if (source['state-updated']) {
+        source.stateUpdated = moment(source['state-updated'], format);
+      }
+
       source.moment = moment(source.date, format);
 
       return source;

--- a/app/components/applications/applications.html
+++ b/app/components/applications/applications.html
@@ -13,8 +13,14 @@
       </md-card-content>
 
       <div class="md-actions inset" layout="row" layout-align="end center">
-        <md-button ng-if="hasBranch('master', tile)" ui-sref='app.applicationsSelected({owner: tile.owner, repo: tile.repo, ref: "master"})'>master</md-button>
-        <md-button ng-if="hasBranch('develop', tile)" class="md-primary" ui-sref='app.applicationsSelected({owner: tile.owner, repo: tile.repo, ref: "develop"})'>develop</md-button>
+        <md-button ng-if="hasBranch('master', tile)" ui-sref='app.applicationsSelected({owner: tile.owner, repo: tile.repo, ref: "master"})'>
+          <md-tooltip>{{ tile.refs.master.state | lowercase }} {{ tile.refs.master.deployments[0].stateUpdated.fromNow() }}</md-tooltip>
+          master
+        </md-button>
+        <md-button ng-if="hasBranch('develop', tile)" class="md-primary" ui-sref='app.applicationsSelected({owner: tile.owner, repo: tile.repo, ref: "develop"})'>
+          <md-tooltip>{{ tile.refs.develop.state | lowercase }} {{ tile.refs.develop.deployments[0].stateUpdated.fromNow() }}</md-tooltip>
+          develop
+        </md-button>
         <md-menu>
           <md-button ng-click="$mdOpenMenu($event)">
             <md-tooltip>branches</md-tooltip>
@@ -23,7 +29,7 @@
           <md-menu-content width="4">
             <md-menu-item ng-repeat="ref in tile.refs">
               <md-button ui-sref='app.applicationsSelected({owner: tile.owner, repo: tile.repo, ref: ref.ref})'>
-                {{ref.ref}}
+                {{ref.ref}} ({{ ref.state | lowercase }} {{ ref.deployments[0].stateUpdated.fromNow() }})
               </md-button>
             </md-menu-item>
           </md-menu-content>

--- a/app/components/applications/selected/applications-selected-controller.js
+++ b/app/components/applications/selected/applications-selected-controller.js
@@ -214,6 +214,7 @@ angular.module('totemDashboard')
     api.getJobEvents(deployment.metaInfo.jobId).then(function(results) {
       updateEvents(results.events, deployment.metaInfo.deployer.name);
       $scope.events = results;
+      $scope.loaded = true;
     });
   });
 
@@ -309,8 +310,6 @@ angular.module('totemDashboard')
       try {
         $scope.selected.deployment = results.ref.deployments[0];
       } catch (err) {}
-
-      $scope.loaded = true;
     }, function(error) {
       $mdToast.show($mdToast.simple().position('top left').content('Error Getting Application!'));
       console.error(error);

--- a/app/components/applications/selected/applications-selected.html
+++ b/app/components/applications/selected/applications-selected.html
@@ -12,9 +12,10 @@
   </div>
 </md-toolbar>
 
-<md-toolbar class="md-accent" ng-if="working">
+<md-toolbar class="md-accent" ng-if="working || !loaded">
   <div class="md-toolbar-tools">
-    <h3>Working </h3>
+    <h3 ng-if="working">Working&hellip;</h3>
+    <h3 ng-if="!loaded">Loading&hellip;</h3>
     <md-progress-circular md-mode="indeterminate" md-diameter="30"></md-progress-circular>
   </div>
 </md-toolbar>
@@ -39,7 +40,7 @@
   </md-switch>
 </div>
 
-<div layout="column" flex="" layout-fill="">
+<div layout="column" flex="" layout-fill="" ng-if="loaded">
   <md-tabs md-dynamic-height md-border-bottom>
     <md-tab label="Summary">
       <md-content layout-padding>

--- a/app/components/applications/selected/applications-selected.html
+++ b/app/components/applications/selected/applications-selected.html
@@ -45,9 +45,9 @@
     <md-tab label="Summary">
       <md-content layout-padding>
         <div layout="row" layout-sm="column">
-          <h3>{{ application.ref.name }} ({{ selected.deployment.state | lowercase }})</h3>
+          <h3>{{ application.ref.name }} ({{ selected.deployment.state | lowercase }} {{ selected.deployment.stateUpdated.fromNow() }})</h3>
           <md-select ng-model="selected.deployment" style="margin-left: 20px;" placeholder="Change Deployment" style="min-width: 200px;">
-            <md-option ng-value="deploy" ng-repeat="deploy in application.ref.deployments">{{deploy.id}} {{ deploy.state | lowercase }}</md-option>
+            <md-option ng-value="deploy" ng-repeat="deploy in application.ref.deployments">{{deploy.id}} {{ deploy.state | lowercase }} {{ deploy.stateUpdated.fromNow() }}</md-option>
           </md-select>
         </div>
 

--- a/app/components/base/base.controller.js
+++ b/app/components/base/base.controller.js
@@ -2,7 +2,7 @@
 'use strict';
 
 /*jshint strict: true */
-/*globals angular, moment*/
+/*globals angular*/
 
 angular.module('totemDashboard')
   .config(['$stateProvider', function ($stateProvider) {
@@ -20,7 +20,6 @@ angular.module('totemDashboard')
       });
   }])
 
-  .controller('BaseController', ['$scope', function ($scope) {
-    $scope.moment = moment;
-  }]);
+  .controller('BaseController', function () {
+  });
 })();

--- a/app/components/base/base.controller.js
+++ b/app/components/base/base.controller.js
@@ -2,7 +2,7 @@
 'use strict';
 
 /*jshint strict: true */
-/*globals angular*/
+/*globals angular, moment*/
 
 angular.module('totemDashboard')
   .config(['$stateProvider', function ($stateProvider) {
@@ -20,6 +20,7 @@ angular.module('totemDashboard')
       });
   }])
 
-  .controller('BaseController', function () {
-  });
+  .controller('BaseController', ['$scope', function ($scope) {
+    $scope.moment = moment;
+  }]);
 })();


### PR DESCRIPTION
Fixes #28 
### Application selected view

![screen shot 2015-09-15 at 8 06 48 am](https://cloud.githubusercontent.com/assets/517295/9880703/934cffca-5b81-11e5-9baf-403c8163e4e5.png)
### Apps view hovering over develop/master buttons

![screen shot 2015-09-15 at 8 07 20 am](https://cloud.githubusercontent.com/assets/517295/9880704/935d8214-5b81-11e5-892a-d3870e890df2.png)
### Apps view branches menu open

![screen shot 2015-09-15 at 8 07 29 am](https://cloud.githubusercontent.com/assets/517295/9880705/93600aac-5b81-11e5-840b-e49e11a3b352.png)

> Note that the decommissioned deployment shown only does not have a timestamp because it was decommissioned before the `state-updated` attribute was added

@mmoulton @sukrit007 let me know what you think
