### PR TITLE
Pending Image Factory Builds

### DIFF
--- a/app/components/image-factory/image-factory-controller.js
+++ b/app/components/image-factory/image-factory-controller.js
@@ -57,7 +57,10 @@ angular.module('totemDashboard')
       url: config.imageFactory.url + '/job'
     }).then(function successCallback(response) {
         _.each(response.data, function(job) {
-          job.startMoment = moment(job.startTime);
+          
+          if(job.startTime) {
+            job.startMoment = moment(job.startTime);
+          }
 
           if (job.endTime) {
             job.endMoment = moment(job.endTime);


### PR DESCRIPTION
### Problem

Image Factory builds that are pending but have not yet started do not show up in the list of jobs. `job.startMoment` would become a moment object with a corrupted time, which filtering would put elsewhere in the list.
### Fix

The fix includes checking if `job.startTime` is populated before handing it off to momentjs. This way, `job.startMoment` becomes `undefined`, and the "ago" filter catches it.
