### PR TITLE
Update dockerignore for better caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,9 @@ dist
 .tmp
 .sass-cache
 app/bower
+.git*
+*.md
+*travis.yml
+*.jshint*
+e2e
+*.editorconfig


### PR DESCRIPTION
This PR makes dockerbuilds during PR go faster. Updated dockerignore list (esp. for .gitignore)
