### PR TITLE
Updating Totem Log URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - '0.12'
-  - '0.10'
-  - 'iojs'
+  - '6.9'
 env: TOTEM_DASHBOARD_CONFIG=config.dev
 before_install:
   - npm install -g gulp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Totem Dashboard v2
 
-# Use node 0.10.x
-FROM totem/nodejs-base:0.10.29-trusty
+# Use node 6.9.x
+FROM mhart/alpine-node:6.9
 
 # Install Gulp & bower
 RUN npm install -g gulp bower
@@ -11,14 +11,29 @@ WORKDIR /opt/totem-dashboard
 # Add files necessary for npm install (For caching purposes)
 ADD package.json /opt/totem-dashboard/
 
-# Install node modules
-RUN rm -rf node_modules; npm install
+RUN apk --update --no-cache add \
+      python \
+      make \
+      gcc \
+      g++ \
+  && npm install \
+  && apk del \
+      python \
+      make \
+      gcc \
+      g++ \
+  && rm -rf ~/.cache /tmp/npm* /root/.npm ~/.npmrc \
+  && mkdir -p /root/.npm
 
 # Add the package and bower files
 ADD bower.json .bowerrc /opt/totem-dashboard/
 
 # Bower build
-RUN bower --allow-root install
+RUN apk --update --no-cache add \
+      git \
+  && bower --allow-root install \
+  && apk del \
+      git
 
 # Update dashboard directory files
 ADD . /opt/totem-dashboard

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Setup
 
-You need [Node.js](https://nodejs.org/) 0.10.x installed (use [nvm](https://github.com/creationix/nvm)).
+You need [Node.js](https://nodejs.org/) 6.9.x installed (use [nvm](https://github.com/creationix/nvm)).
 
 Once node is running, you will need [Gulp](http://gulpjs.com/) and [Bower](http://bower.io/) installed globally to run the project
 

--- a/app/components/api/api.service.js
+++ b/app/components/api/api.service.js
@@ -359,17 +359,9 @@ angular.module('totemDashboard')
   }])
 
   .service('logs', ['config', '$websocket', function(config, $websocket) {
-    var cache = {};
-
     this.connect = function() {
-      var domain = config.domain;
-
-      // TODO: determine if we should cache the websocket handle or not
-      if (!cache[domain]) {
-        cache[domain] = 'wss://totem-logs.' + domain + '/logs';
-      }
-
-      return $websocket(cache[domain]);
+      var logUrl = config.logs.url;
+      return $websocket(logUrl);
     };
   }])
 ;

--- a/app/components/config/config.service.test.js
+++ b/app/components/config/config.service.test.js
@@ -8,10 +8,12 @@ describe('Controller: config', function() {
       httpBackend;
 
   var settings = {
-    domain: 'totem-dashboard.dev',
     elasticsearch: {
       index: 'totem-production',
       url: 'elasticsearch.dev'
+    },
+    logs: {
+      url: 'wss://totem-production.dev/logs'
     }
   };
 

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "totemDashboard",
+  "name": "totem-dashboard",
   "version": "0.0.0",
   "dependencies": {
     "DateJS": "~1.0.0-rc3",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -240,7 +240,7 @@ gulp.task('serve:test', ['config'], function() {
 gulp.task('serve:prod', ['config'], serve({
     root: ['dist'],
     port: 3000,
-    host: '0.0.0.0'
+    hostname: '0.0.0.0'
 }));
 
 // Default task

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -239,7 +239,8 @@ gulp.task('serve:test', ['config'], function() {
 
 gulp.task('serve:prod', ['config'], serve({
     root: ['dist'],
-    port: 3000
+    port: 3000,
+    host: '0.0.0.0'
 }));
 
 // Default task

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "totemDashboard",
+  "name": "totem-dashboard",
   "version": "0.0.0",
   "scripts": {
     "test": "./node_modules/.bin/gulp test && ./node_modules/.bin/gulp protractor:dist"
@@ -33,7 +33,7 @@
     "protractor": "^2.1.0"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=6.9"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Needed to update the url for the totem logs after the SSL changes. This fix goes along with a [totem-config](https://github.com/totem/totem-config/pull/35) PR that updates the configuration properties. The log URL is now pulled from the `logs.url` property.

The node version was also updated to 6.9, because 0.10 is freakin' old. The `Dockerfile` updates are for the migration to 6.9.